### PR TITLE
[1.0.1] feat(models): add @ServiceModel support and proxy generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           ./gradlew :spruce-api:publish \
                      :spruce-processor:spruce-processor-commons:publish \
+                     :spruce-processor:spruce-processor-models:publish \
                      :spruce-processor:spruce-processor-spigot:publish \
                      :spruce-processor:spruce-processor-velocity:publish \
                      --no-daemon || echo "⚠️ Already published or failed — skipping."

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ repositories {
 
 ```kotlin
 dependencies {
-    implementation("org.spruce:spruce-api:1.0.0")
+    implementation("org.spruce:spruce-api:1.0.1")
 }
 ```
 
@@ -61,10 +61,10 @@ plugins {
 
 dependencies {
     // For Spigot plugins
-    ksp("org.spruce:spruce-processor-spigot:1.0.0")
+    ksp("org.spruce:spruce-processor-spigot:1.0.1")
 
     // Or for Velocity plugins
-    ksp("org.spruce:spruce-processor-velocity:1.0.0")
+    ksp("org.spruce:spruce-processor-velocity:1.0.1")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 allprojects {
     group = "org.spruce"
-    version = "1.0.0"
+    version = "1.0.1"
 
     repositories {
         mavenCentral()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,3 +20,5 @@ include("spruce-processor:spruce-processor-spigot")
 findProject(":spruce-processor:spruce-processor-spigot")?.name = "spruce-processor-spigot"
 include("spruce-processor:spruce-processor-velocity")
 findProject(":spruce-processor:spruce-processor-velocity")?.name = "spruce-processor-velocity"
+include("spruce-processor:spruce-processor-models")
+findProject(":spruce-processor:spruce-processor-models")?.name = "spruce-processor-models"

--- a/spruce-api/src/main/java/org/spruce/api/service/ServiceCall.java
+++ b/spruce-api/src/main/java/org/spruce/api/service/ServiceCall.java
@@ -1,0 +1,27 @@
+package org.spruce.api.service;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Overrides the default method name used when calling a service through the gateway.
+ * <p>
+ * By default, the method name in the interface is used as the gateway action name.
+ * This annotation allows you to explicitly specify a different action name.
+ * <p>
+ * Example:
+ * <p>
+ * {@code
+ * @ServiceCall("fetchFriends")
+ * CompletableFuture<GetFriendsResponse> getFriends(GetFriendsRequest request);
+ * }
+ *
+ * In this case, the gateway will call action "fetchFriends" instead of "getFriends".
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ServiceCall {
+    String value();
+}

--- a/spruce-api/src/main/java/org/spruce/api/service/ServiceModel.java
+++ b/spruce-api/src/main/java/org/spruce/api/service/ServiceModel.java
@@ -1,0 +1,15 @@
+package org.spruce.api.service;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for registering a class as a service model.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ServiceModel {
+    String value();
+}

--- a/spruce-gateway/Dockerfile
+++ b/spruce-gateway/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:21-jdk-slim
 
 WORKDIR /app
 
-COPY build/libs/spruce-gateway-1.0.0.jar app.jar
+COPY build/libs/spruce-gateway-1.0.1.jar app.jar
 
 EXPOSE 6565
 

--- a/spruce-loader/spruce-loader-spigot/src/main/resources/plugin.yml
+++ b/spruce-loader/spruce-loader-spigot/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
 name: Spruce
-version: 1.0.0
+version: 1.0.1
 main: org.spruce.loader.spigot.SpruceLoaderSpigotPlugin
 api-version: 1.20

--- a/spruce-loader/spruce-loader-velocity/src/main/kotlin/org/spruce/loader/velocity/SpruceLoaderVelocityPlugin.kt
+++ b/spruce-loader/spruce-loader-velocity/src/main/kotlin/org/spruce/loader/velocity/SpruceLoaderVelocityPlugin.kt
@@ -19,7 +19,7 @@ import java.util.logging.Logger
 @Plugin(
     id = "spruce",
     name = "Spruce",
-    version = "1.0.0",
+    version = "1.0.1",
     authors = ["Spruce"]
 )
 class SpruceLoaderVelocityPlugin @Inject constructor(

--- a/spruce-processor/spruce-processor-commons/src/main/kotlin/org/spruce/processor/commons/AbstractSprucePluginProcessor.kt
+++ b/spruce-processor/spruce-processor-commons/src/main/kotlin/org/spruce/processor/commons/AbstractSprucePluginProcessor.kt
@@ -10,7 +10,7 @@ import org.spruce.processor.commons.generator.impl.*
 import java.io.OutputStreamWriter
 
 abstract class AbstractSprucePluginProcessor(
-    private val environment: SymbolProcessorEnvironment
+    protected val environment: SymbolProcessorEnvironment
 ) : SymbolProcessor {
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
@@ -77,13 +77,17 @@ abstract class AbstractSprucePluginProcessor(
         GlobalEventListenerRegistryGenerator.process(component, environment)
     }
 
+    open fun processServiceModelProxy(component: KSClassDeclaration, environment: SymbolProcessorEnvironment): Boolean {
+        return ServiceModelProxyGenerator.process(component, environment)
+    }
+
     abstract fun processCommandRegistry(component: KSClassDeclaration, environment: SymbolProcessorEnvironment)
     abstract fun processEventListenerRegistry(component: KSClassDeclaration, environment: SymbolProcessorEnvironment)
     abstract fun processScheduledTaskRegistry(component: KSClassDeclaration, environment: SymbolProcessorEnvironment)
     abstract fun processFileConfigLoader(component: KSClassDeclaration, environment: SymbolProcessorEnvironment)
 }
 
-private fun SymbolProcessorEnvironment.writeToFile(fileName: String, lines: List<String>) {
+fun SymbolProcessorEnvironment.writeToFile(fileName: String, lines: List<String>) {
     val file = this.codeGenerator.createNewFile(
         Dependencies(false), "META-INF", fileName, "txt"
     )

--- a/spruce-processor/spruce-processor-commons/src/main/kotlin/org/spruce/processor/commons/generator/impl/ServiceModelProxyGenerator.kt
+++ b/spruce-processor/spruce-processor-commons/src/main/kotlin/org/spruce/processor/commons/generator/impl/ServiceModelProxyGenerator.kt
@@ -1,0 +1,100 @@
+package org.spruce.processor.commons.generator.impl
+
+import com.google.devtools.ksp.processing.Dependencies
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.symbol.*
+import org.spruce.processor.commons.generator.CodeGenerator
+import java.io.OutputStreamWriter
+import java.util.concurrent.CompletableFuture
+
+object ServiceModelProxyGenerator : CodeGenerator {
+
+    private val skipMethods = setOf("equals", "hashCode", "toString")
+
+    override fun process(clazz: KSClassDeclaration, environment: SymbolProcessorEnvironment): Boolean {
+        val annotation = clazz.annotations.firstOrNull {
+            it.annotationType.resolve().declaration.qualifiedName?.asString() == "org.spruce.api.service.ServiceModel"
+        } ?: return false
+
+        if (clazz.classKind != ClassKind.INTERFACE) {
+            environment.logger.error("@ServiceModel must be applied to interface", clazz)
+            return false
+        }
+
+        val serviceName = annotation.arguments.find { it.name?.asString() == "value" || it.name?.asString() == "service" }
+            ?.value as? String ?: return false
+
+        val packageName = clazz.containingFile?.packageName?.asString()?.takeIf { it.isNotBlank() }
+            ?: throw IllegalStateException("Can't determine package for ${clazz.simpleName.asString()}")
+
+        val simpleName = clazz.simpleName.asString()
+        val qualifiedName = clazz.qualifiedName?.asString() ?: return false
+        val fileName = "${simpleName}__Proxy"
+
+        val file = environment.codeGenerator.createNewFile(
+            Dependencies(false), packageName, fileName
+        )
+
+        OutputStreamWriter(file, Charsets.UTF_8).use { writer ->
+            writer.write("package $packageName\n\n")
+            writer.write("import $qualifiedName\n")
+            writer.write("import org.spruce.api.gateway.GatewayCall\n")
+            writer.write("import org.spruce.api.gateway.SpruceGatewayClient\n")
+            writer.write("import java.util.concurrent.CompletableFuture\n")
+            writer.write("import javax.annotation.processing.Generated\n\n")
+
+            writer.write("@Generated(\"Spruce KSP\")\n")
+            writer.write("class $fileName(private val gatewayClient: SpruceGatewayClient) : $simpleName {\n")
+
+            for (function in clazz.getAllFunctions()) {
+                val methodName = function.simpleName.asString()
+
+                if (methodName in skipMethods) continue
+
+                val returnType = function.returnType?.resolve()
+                val returnTypeName = returnType?.declaration?.qualifiedName?.asString()
+
+                if (returnTypeName != CompletableFuture::class.java.name) {
+                    environment.logger.error("Method $methodName must return CompletableFuture<T>", function)
+                    continue
+                }
+
+                val typeArg = returnType?.arguments?.firstOrNull()?.type?.resolve()
+                val responseTypeFqcn = typeArg?.declaration?.qualifiedName?.asString() ?: continue
+
+                if (function.parameters.size != 1) {
+                    environment.logger.error("Method $methodName must have exactly one argument", function)
+                    continue
+                }
+
+                val param = function.parameters.first()
+                val paramFqcn = param.type.resolve().declaration.qualifiedName?.asString() ?: continue
+                val paramName = "request"
+
+                val serviceCallAnnotation = function.annotations.firstOrNull {
+                    it.annotationType.resolve().declaration.qualifiedName?.asString() == "org.spruce.api.service.ServiceCall"
+                }
+
+                val actionName = serviceCallAnnotation
+                    ?.arguments
+                    ?.find { it.name?.asString() == "value" }
+                    ?.value as? String ?: methodName
+
+                writer.write("    override fun $methodName($paramName: $paramFqcn): CompletableFuture<$responseTypeFqcn> {\n")
+                writer.write("        return gatewayClient.call(\n")
+                writer.write("            GatewayCall.of(\n")
+                writer.write("                \"$serviceName\",\n")
+                writer.write("                \"$actionName\",\n")
+                writer.write("                $paramName,\n")
+                writer.write("                $responseTypeFqcn::class.java\n")
+                writer.write("            )\n")
+                writer.write("        )\n")
+                writer.write("    }\n\n")
+            }
+
+            writer.write("}")
+        }
+
+        return true
+    }
+}

--- a/spruce-processor/spruce-processor-models/build.gradle.kts
+++ b/spruce-processor/spruce-processor-models/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    kotlin("jvm")
+    id("com.google.devtools.ksp") version "1.9.22-1.0.16"
+}
+
+dependencies {
+    implementation(project(":spruce-api"))
+    implementation(project(":spruce-processor:spruce-processor-commons"))
+
+    implementation("com.google.devtools.ksp:symbol-processing-api:1.9.22-1.0.16")
+}

--- a/spruce-processor/spruce-processor-models/src/main/kotlin/org/spruce/processor/models/SprucePluginProcessorModels.kt
+++ b/spruce-processor/spruce-processor-models/src/main/kotlin/org/spruce/processor/models/SprucePluginProcessorModels.kt
@@ -1,0 +1,35 @@
+package org.spruce.processor.models
+
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import org.spruce.processor.commons.AbstractSprucePluginProcessor
+import org.spruce.processor.commons.writeToFile
+
+class SprucePluginProcessorModels(environment: SymbolProcessorEnvironment) : AbstractSprucePluginProcessor(environment) {
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        val modelClassNames = mutableListOf<String>()
+        val serviceModels = resolver.getSymbolsWithAnnotation("org.spruce.api.service.ServiceModel")
+            .filterIsInstance<KSClassDeclaration>()
+
+        for (model in serviceModels) {
+            if (processServiceModelProxy(model, environment)) {
+                val className = model.qualifiedName?.asString() ?: continue
+                modelClassNames.add(className)
+            }
+        }
+
+        if (modelClassNames.isNotEmpty()) {
+            environment.writeToFile("spruce.models", modelClassNames)
+        }
+
+        return emptyList()
+    }
+
+    override fun processCommandRegistry(component: KSClassDeclaration, environment: SymbolProcessorEnvironment) {}
+    override fun processEventListenerRegistry(component: KSClassDeclaration, environment: SymbolProcessorEnvironment) {}
+    override fun processScheduledTaskRegistry(component: KSClassDeclaration, environment: SymbolProcessorEnvironment) {}
+    override fun processFileConfigLoader(component: KSClassDeclaration, environment: SymbolProcessorEnvironment) {}
+}

--- a/spruce-processor/spruce-processor-models/src/main/kotlin/org/spruce/processor/models/SprucePluginProcessorProviderModels.kt
+++ b/spruce-processor/spruce-processor-models/src/main/kotlin/org/spruce/processor/models/SprucePluginProcessorProviderModels.kt
@@ -1,0 +1,10 @@
+package org.spruce.processor.models
+
+import com.google.devtools.ksp.processing.*
+
+class SprucePluginProcessorProviderModels : SymbolProcessorProvider {
+
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+        return SprucePluginProcessorModels(environment)
+    }
+}

--- a/spruce-processor/spruce-processor-models/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/spruce-processor/spruce-processor-models/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,0 +1,1 @@
+org.spruce.processor.models.SprucePluginProcessorProviderModels


### PR DESCRIPTION
- Introduced `@ServiceModel` annotation to define service interfaces
- Implemented KSP-based proxy generation for service calls
- Added separate processor module (spruce-processor-models) to generate proxies before plugins are loaded
- Generated model class names are stored in a `spruce.models.txt` file
- Enhanced SpruceServiceBase to auto-register interface methods as actions
- Fixed ClassNotFoundException and duplicate generation issues
- Bumped version to 1.0.1 across all modules